### PR TITLE
Resolve testcontainers issue

### DIFF
--- a/DREAM/idaas-dream-demo/pom.xml
+++ b/DREAM/idaas-dream-demo/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
-      <version>1.15.0</version>
+      <version>1.15.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Resolve
```
Error:  com.redhat.idaas.dream.demo.UsingKafkaIT  Time elapsed: 1.451 s  <<< ERROR!
org.testcontainers.containers.ContainerLaunchException: Container startup failed
Caused by: org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=confluentinc/cp-kafka:5.4.3, imagePullPolicy=DefaultPullPolicy())
Caused by: com.github.dockerjava.api.exception.NotFoundException:
Status 404: {"message":"No such image: testcontainers/ryuk:0.3.0"}
```

as in
https://github.com/RedHat-Healthcare/iDaaS-Demos/runs/2191620164#step:4:2596

similar to
https://github.com/kiegroup/kogito-runtimes/pull/959
https://github.com/testcontainers/testcontainers-java/issues/3574

Bumping Testcontainers version should fix it when integration tests are running as GitHub Actions