### PR TITLE
CI as one GH action per each subdirectory of demos

### DIFF
--- a/.github/workflows/build_connect-aggregator.yml
+++ b/.github/workflows/build_connect-aggregator.yml
@@ -1,11 +1,16 @@
-name: CI for DREAM demo
+name: CI for Connect-Aggregator demo
 
 on:
   pull_request:
     branches:
       - master
     paths:
-      - 'DREAM/**'
+      - 'Connect-Aggregator/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'Connect-Aggregator/**'
 
 jobs:
   publish:
@@ -22,4 +27,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B clean verify --fae --file DREAM/pom.xml
+        run: mvn -B clean verify --fae --file Connect-Aggregator/pom.xml

--- a/.github/workflows/build_connect-bluebutton.yml
+++ b/.github/workflows/build_connect-bluebutton.yml
@@ -1,11 +1,16 @@
-name: CI for DREAM demo
+name: CI for Connect-BlueButton demo
 
 on:
   pull_request:
     branches:
       - master
     paths:
-      - 'DREAM/**'
+      - 'Connect-BlueButton/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'Connect-BlueButton/**'
 
 jobs:
   publish:
@@ -22,4 +27,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B clean verify --fae --file DREAM/pom.xml
+        run: mvn -B clean verify --fae --file Connect-BlueButton/pom.xml

--- a/.github/workflows/build_connect-edi.yml
+++ b/.github/workflows/build_connect-edi.yml
@@ -1,11 +1,16 @@
-name: CI for DREAM demo
+name: CI for Connect-EDI demo
 
 on:
   pull_request:
     branches:
       - master
     paths:
-      - 'DREAM/**'
+      - 'Connect-EDI/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'Connect-EDI/**'
 
 jobs:
   publish:
@@ -22,4 +27,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B clean verify --fae --file DREAM/pom.xml
+        run: mvn -B clean verify --fae --file Connect-EDI/pom.xml

--- a/.github/workflows/build_connect-fhir-datatagging.yml
+++ b/.github/workflows/build_connect-fhir-datatagging.yml
@@ -1,11 +1,16 @@
-name: CI for DREAM demo
+name: CI for Connect-FHIR-DataTagging demo
 
 on:
   pull_request:
     branches:
       - master
     paths:
-      - 'DREAM/**'
+      - 'Connect-FHIR-DataTagging/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'Connect-FHIR-DataTagging/**'
 
 jobs:
   publish:
@@ -22,4 +27,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B clean verify --fae --file DREAM/pom.xml
+        run: mvn -B clean verify --fae --file Connect-FHIR-DataTagging/pom.xml

--- a/.github/workflows/build_connect-fhir.yml
+++ b/.github/workflows/build_connect-fhir.yml
@@ -1,11 +1,16 @@
-name: CI for DREAM demo
+name: CI for Connect-FHIR demo
 
 on:
   pull_request:
     branches:
       - master
     paths:
-      - 'DREAM/**'
+      - 'Connect-FHIR/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'Connect-FHIR/**'
 
 jobs:
   publish:
@@ -22,4 +27,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B clean verify --fae --file DREAM/pom.xml
+        run: mvn -B clean verify --fae --file Connect-FHIR/pom.xml

--- a/.github/workflows/build_connect-hl7.yml
+++ b/.github/workflows/build_connect-hl7.yml
@@ -1,11 +1,16 @@
-name: CI for DREAM demo
+name: CI for Connect-HL7 demo
 
 on:
   pull_request:
     branches:
       - master
     paths:
-      - 'DREAM/**'
+      - 'Connect-HL7/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'Connect-HL7/**'
 
 jobs:
   publish:
@@ -22,4 +27,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B clean verify --fae --file DREAM/pom.xml
+        run: mvn -B clean verify --fae --file Connect-HL7/pom.xml

--- a/.github/workflows/build_connect-route-datadistribution.yml
+++ b/.github/workflows/build_connect-route-datadistribution.yml
@@ -1,11 +1,16 @@
-name: CI for DREAM demo
+name: CI for Route-DataDistribution demo
 
 on:
   pull_request:
     branches:
       - master
     paths:
-      - 'DREAM/**'
+      - 'Route-DataDistribution/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'Route-DataDistribution/**'
 
 jobs:
   publish:
@@ -22,4 +27,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B clean verify --fae --file DREAM/pom.xml
+        run: mvn -B clean verify --fae --file Route-DataDistribution/pom.xml

--- a/.github/workflows/build_connect-thirdparty.yml
+++ b/.github/workflows/build_connect-thirdparty.yml
@@ -1,11 +1,16 @@
-name: CI for DREAM demo
+name: CI for Connect-ThirdParty demo
 
 on:
   pull_request:
     branches:
       - master
     paths:
-      - 'DREAM/**'
+      - 'Connect-ThirdParty/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'Connect-ThirdParty/**'
 
 jobs:
   publish:
@@ -22,4 +27,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B clean verify --fae --file DREAM/pom.xml
+        run: mvn -B clean verify --fae --file Connect-ThirdParty/pom.xml

--- a/.github/workflows/build_idaas-kic.yml
+++ b/.github/workflows/build_idaas-kic.yml
@@ -1,11 +1,16 @@
-name: CI for DREAM demo
+name: CI for iDaaS-KIC demo
 
 on:
   pull_request:
     branches:
       - master
     paths:
-      - 'DREAM/**'
+      - 'iDaaS-KIC/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'iDaaS-KIC/**'
 
 jobs:
   publish:
@@ -22,4 +27,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B clean verify --fae --file DREAM/pom.xml
+        run: mvn -B clean verify --fae --file iDaaS-KIC/iDaaS-KIC-Integration/pom.xml

--- a/.github/workflows/deploy_dream.yml
+++ b/.github/workflows/deploy_dream.yml
@@ -1,7 +1,7 @@
-name: CI for DREAM demo
+name: deploy DREAM demo
 
 on:
-  pull_request:
+  push:
     branches:
       - master
     paths:
@@ -21,5 +21,7 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Build with Maven
-        run: mvn -B clean verify --fae --file DREAM/pom.xml
+      - name: Build and Deploy package
+        run: mvn -B clean deploy --fae --file DREAM/pom.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
imho this is the less invasive option to start with, and would not fail for the overall repo if only 1 specific demo fails for whichever reason.

This proposed solution is implementing _one github action taking care of pull-request and merge per each demo_; when a PR to modify an existing demo is raised, it can be used check the Maven build status (including tests if the demo have any tests written), and the same is applied on merge of the demo.

The demo `/Connect-FHIR-DataTagging-Watson` does not contain any `pom.xml` file, hence it was not possible to include it with this task.